### PR TITLE
[TECHNICAL-SUPPORT] LPS-87577 AssetDisplayPageEntry upgrade

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/JournalServiceUpgrade.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/JournalServiceUpgrade.java
@@ -47,6 +47,7 @@ import com.liferay.journal.internal.upgrade.v1_1_2.UpgradeCheckIntervalConfigura
 import com.liferay.journal.internal.upgrade.v1_1_3.UpgradeResourcePermissions;
 import com.liferay.journal.internal.upgrade.v1_1_4.UpgradeUrlTitle;
 import com.liferay.journal.internal.upgrade.v1_1_5.UpgradeContentImages;
+import com.liferay.journal.internal.upgrade.v1_1_6.UpgradeAssetDisplayPageEntry;
 import com.liferay.journal.internal.upgrade.v2_0_0.util.JournalArticleTable;
 import com.liferay.journal.internal.upgrade.v2_0_0.util.JournalFeedTable;
 import com.liferay.journal.internal.upgrade.v2_0_0.util.JournalFolderTable;
@@ -176,8 +177,10 @@ public class JournalServiceUpgrade implements UpgradeStepRegistrator {
 			"1.1.4", "1.1.5",
 			new UpgradeContentImages(_journalArticleImageUpgradeUtil));
 
+		registry.register("1.1.5", "1.1.6", new UpgradeAssetDisplayPageEntry());
+
 		registry.register(
-			"1.1.5", "2.0.0",
+			"1.1.6", "2.0.0",
 			new BaseUpgradeSQLServerDatetime(
 				new Class<?>[] {
 					JournalArticleTable.class, JournalFeedTable.class,

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/JournalServiceUpgrade.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/JournalServiceUpgrade.java
@@ -14,6 +14,7 @@
 
 package com.liferay.journal.internal.upgrade;
 
+import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
@@ -177,7 +178,10 @@ public class JournalServiceUpgrade implements UpgradeStepRegistrator {
 			"1.1.4", "1.1.5",
 			new UpgradeContentImages(_journalArticleImageUpgradeUtil));
 
-		registry.register("1.1.5", "1.1.6", new UpgradeAssetDisplayPageEntry());
+		registry.register(
+			"1.1.5", "1.1.6",
+			new UpgradeAssetDisplayPageEntry(
+				_assetDisplayPageEntryLocalService));
 
 		registry.register(
 			"1.1.6", "2.0.0",
@@ -323,6 +327,11 @@ public class JournalServiceUpgrade implements UpgradeStepRegistrator {
 		JournalServiceUpgrade.class);
 
 	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Reference
+	private AssetDisplayPageEntryLocalService
+		_assetDisplayPageEntryLocalService;
+
 	private AssetEntryLocalService _assetEntryLocalService;
 	private AssetVocabularyLocalService _assetVocabularyLocalService;
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/UpgradeAssetDisplayPageEntry.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/UpgradeAssetDisplayPageEntry.java
@@ -86,7 +86,8 @@ public class UpgradeAssetDisplayPageEntry extends UpgradeProcess {
 					SaveAssetDisplayPageEntryCallable
 						saveAssetDisplayPageEntryCallable =
 							new SaveAssetDisplayPageEntryCallable(
-								groupId, userId, resourcePrimKey);
+								groupId, userId, journalArticleClassNameId,
+								resourcePrimKey);
 
 					saveAssetDisplayPageEntryCallables.add(
 						saveAssetDisplayPageEntryCallable);
@@ -112,9 +113,6 @@ public class UpgradeAssetDisplayPageEntry extends UpgradeProcess {
 		}
 	}
 
-	private static final long _CLASS_NAME_ID = PortalUtil.getClassNameId(
-		JournalArticle.class);
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		UpgradeAssetDisplayPageEntry.class);
 
@@ -125,10 +123,11 @@ public class UpgradeAssetDisplayPageEntry extends UpgradeProcess {
 		implements Callable<Boolean> {
 
 		public SaveAssetDisplayPageEntryCallable(
-			long groupId, long userId, long classPK) {
+			long groupId, long userId, long classNameId, long classPK) {
 
 			_groupId = groupId;
 			_userId = userId;
+			_classNameId = classNameId;
 			_classPK = classPK;
 		}
 
@@ -140,7 +139,7 @@ public class UpgradeAssetDisplayPageEntry extends UpgradeProcess {
 				serviceContext.setUuid(PortalUUIDUtil.generate());
 
 				_assetDisplayPageEntryLocalService.addAssetDisplayPageEntry(
-					_userId, _groupId, _CLASS_NAME_ID, _classPK, 0,
+					_userId, _groupId, _classNameId, _classPK, 0,
 					AssetDisplayPageConstants.TYPE_SPECIFIC, serviceContext);
 			}
 			catch (Exception e) {
@@ -155,6 +154,7 @@ public class UpgradeAssetDisplayPageEntry extends UpgradeProcess {
 			return true;
 		}
 
+		private final long _classNameId;
 		private final long _classPK;
 		private final long _groupId;
 		private final long _userId;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/UpgradeAssetDisplayPageEntry.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/UpgradeAssetDisplayPageEntry.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.internal.upgrade.v1_1_6;
+
+import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+
+/**
+ * @author Vendel Toreki
+ */
+public class UpgradeAssetDisplayPageEntry extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		updateAssetDisplayPageEntry();
+	}
+
+	protected void updateAssetDisplayPageEntry() throws Exception {
+		StringBuilder sb = new StringBuilder(9);
+
+		sb.append("select groupId, companyId, userId, userName, createDate, ");
+		sb.append("resourcePrimKey from JournalArticle where ");
+		sb.append("JournalArticle.layoutUuid is not null and ");
+		sb.append("JournalArticle.layoutUuid != '' and not exists ( ");
+		sb.append("select 1 from AssetDisplayPageEntry where ");
+		sb.append("AssetDisplayPageEntry.groupId = JournalArticle.groupId ");
+		sb.append("and AssetDisplayPageEntry.classNameId = ? and ");
+		sb.append("AssetDisplayPageEntry.classPK = ");
+		sb.append("JournalArticle.resourcePrimKey )");
+
+		long journalArticleClassNameId = PortalUtil.getClassNameId(
+			JournalArticle.class);
+
+		try (LoggingTimer loggingTimer = new LoggingTimer();
+			PreparedStatement ps1 = connection.prepareStatement(sb.toString());
+			PreparedStatement ps2 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection, _createInsertSql());) {
+
+			ps1.setLong(1, journalArticleClassNameId);
+
+			try (ResultSet rs = ps1.executeQuery()) {
+				while (rs.next()) {
+					long groupId = rs.getLong("groupId");
+					long companyId = rs.getLong("companyId");
+					long userId = rs.getLong("userId");
+					String userName = rs.getString("userName");
+					Timestamp createDate = rs.getTimestamp("createDate");
+					long resourcePrimKey = rs.getLong("resourcePrimKey");
+
+					ps2.setString(1, PortalUUIDUtil.generate());
+					ps2.setLong(2, increment());
+					ps2.setLong(3, groupId);
+					ps2.setLong(4, companyId);
+					ps2.setLong(5, userId);
+					ps2.setString(6, userName);
+					ps2.setTimestamp(7, createDate);
+					ps2.setTimestamp(8, createDate);
+					ps2.setLong(9, journalArticleClassNameId);
+					ps2.setLong(10, resourcePrimKey);
+					ps2.setLong(11, 0);
+					ps2.setInt(12, AssetDisplayPageConstants.TYPE_SPECIFIC);
+
+					ps2.addBatch();
+				}
+
+				ps2.executeBatch();
+			}
+		}
+	}
+
+	private String _createInsertSql() {
+		StringBuilder sb = new StringBuilder(5);
+
+		sb.append("insert into AssetDisplayPageEntry (uuid_, ");
+		sb.append("assetDisplayPageEntryId, groupId, companyId, userId, ");
+		sb.append("userName, createDate, modifiedDate, classNameId, ");
+		sb.append("classPK, layoutPageTemplateEntryId, type_) values ");
+		sb.append("(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+
+		return sb.toString();
+	}
+
+}


### PR DESCRIPTION
Hi @pavel-savinov ,

I checked the error in previous [pull](https://github.com/brianchandotcom/liferay-portal/pull/65489#issuecomment-443321424). It seems like `JournalArticle` class is renamed from `com.liferay.portlet.journal.model.JournalArticle` to `com.liferay.journal.model.JournalArticle` during the 6.2 ==> 7.0 upgrade process. When it's declared as a static variable, `className_` table still contains the old name, while the query creates a new entry with the new name. This entry is deleted later when the rename actually happens.
To solve this, I added the `classNameId` to the variables of `SaveAssetDisplayPageEntryCallable` in commit https://github.com/pavel-savinov/liferay-portal/commit/41e1deb1f3c33f30755e33f8e93d39f42f25e015

Please review my code.

Thanks,
Vendel