### PR TITLE
Revert "LPS-84229 only import siteNavigationMenuItem if the layout is published as well"

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
@@ -86,9 +86,7 @@ public class LayoutSiteNavigationMenuItemType
 			return false;
 		}
 
-		if (!ArrayUtil.contains(
-				portletDataContext.getLayoutIds(), layout.getLayoutId())) {
-
+		if (!ArrayUtil.contains(portletDataContext.getLayoutIds(), layout.getLayoutId())) {
 			return false;
 		}
 

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -83,10 +82,6 @@ public class LayoutSiteNavigationMenuItemType
 		Layout layout = _getLayout(siteNavigationMenuItem);
 
 		if (layout == null) {
-			return false;
-		}
-
-		if (!ArrayUtil.contains(portletDataContext.getLayoutIds(), layout.getLayoutId())) {
 			return false;
 		}
 

--- a/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/exportimport/data/handler/SiteNavigationMenuItemStagedModelDataHandler.java
+++ b/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/exportimport/data/handler/SiteNavigationMenuItemStagedModelDataHandler.java
@@ -74,8 +74,6 @@ public class SiteNavigationMenuItemStagedModelDataHandler
 				portletDataContext, siteNavigationMenuItemElement,
 				siteNavigationMenuItem)) {
 
-			siteNavigationMenuItemElement.detach();
-
 			return;
 		}
 


### PR DESCRIPTION
Hi @pavel-savinov ,
LPS: [LPS-89487](https://issues.liferay.com/browse/LPS-89487)
This pull reverts the commits done for [LPS-84229](https://issues.liferay.com/browse/LPS-84229) because the changes made in the class [LayoutSiteNavigationMenuItemType](https://github.com/brianchandotcom/liferay-portal/pull/62034/commits/8ac4ad29b5f12f261b21a79b5abd356f3dfc14f1) killed the possibility of publishing changes done in site navigation menus without publishing all the layouts involved in the same publication.

In this case, the customer has all the layouts already published in live and he just wants to publish the changes made in the navigation menus.

I re-tested LPS-84229 following the reproduction steps and couldn't reproduce it after the revert so I suppose it got fixed somewhere else.
Could you take a look at this?
Thanks!