### PR TITLE
LPS-90108 Next item if we already modified the record

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -554,6 +554,8 @@ public class FriendlyURLEntryLocalServiceImpl
 
 				updateFriendlyURLLocalization(
 					existingFriendlyURLEntryLocalization);
+
+				continue;
 			}
 
 			updateFriendlyURLEntryLocalization(

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -532,13 +532,31 @@ public class FriendlyURLEntryLocalServiceImpl
 				(existingFriendlyURLEntryLocalization.getClassPK() ==
 					classPK)) {
 
-				existingFriendlyURLEntryLocalization.setFriendlyURLEntryId(
-					friendlyURLEntry.getFriendlyURLEntryId());
+				String existingLanguageId =
+					existingFriendlyURLEntryLocalization.getLanguageId();
 
-				updateFriendlyURLLocalization(
-					existingFriendlyURLEntryLocalization);
+				if (existingLanguageId.equals(entry.getKey())) {
+					existingFriendlyURLEntryLocalization.setFriendlyURLEntryId(
+						friendlyURLEntry.getFriendlyURLEntryId());
 
-				continue;
+					updateFriendlyURLLocalization(
+						existingFriendlyURLEntryLocalization);
+
+					continue;
+				}
+
+				String urlTitle = urlTitleMap.get(existingLanguageId);
+
+				if (!urlTitle.equals(
+						existingFriendlyURLEntryLocalization.getUrlTitle())) {
+
+					friendlyURLEntryLocalizationPersistence.remove(
+						existingFriendlyURLEntryLocalization.
+							getFriendlyURLEntryLocalizationId());
+				}
+				else {
+					continue;
+				}
 			}
 
 			updateFriendlyURLEntryLocalization(

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -535,28 +535,25 @@ public class FriendlyURLEntryLocalServiceImpl
 				String existingLanguageId =
 					existingFriendlyURLEntryLocalization.getLanguageId();
 
-				if (existingLanguageId.equals(entry.getKey())) {
-					existingFriendlyURLEntryLocalization.setFriendlyURLEntryId(
-						friendlyURLEntry.getFriendlyURLEntryId());
+				if (!existingLanguageId.equals(entry.getKey())) {
+					String existingUrlTitle =
+						existingFriendlyURLEntryLocalization.getUrlTitle();
 
-					updateFriendlyURLLocalization(
-						existingFriendlyURLEntryLocalization);
+					if (existingUrlTitle.equals(
+							urlTitleMap.get(existingLanguageId))) {
 
-					continue;
+						continue;
+					}
+
+					existingFriendlyURLEntryLocalization.setLanguageId(
+						entry.getKey());
 				}
 
-				String urlTitle = urlTitleMap.get(existingLanguageId);
+				existingFriendlyURLEntryLocalization.setFriendlyURLEntryId(
+					friendlyURLEntry.getFriendlyURLEntryId());
 
-				if (!urlTitle.equals(
-						existingFriendlyURLEntryLocalization.getUrlTitle())) {
-
-					friendlyURLEntryLocalizationPersistence.remove(
-						existingFriendlyURLEntryLocalization.
-							getFriendlyURLEntryLocalizationId());
-				}
-				else {
-					continue;
-				}
+				updateFriendlyURLLocalization(
+					existingFriendlyURLEntryLocalization);
 			}
 
 			updateFriendlyURLEntryLocalization(


### PR DESCRIPTION
Hi @pavel-savinov,

I have realized that there was a bug reusing friendlyURLs in the method _updateFriendlyURLEntryLocalizations, that caused the test to fail. I have solved it with these changes.

I think it's better to solve in FriendlyURLEntryLocalServiceImpl since in this way will be fixed for other components using the friendlyURL framework.

Let's wait for the final result of the tests.

Cheers.