### PR TITLE
[TECHNICAL-SUPPORT] LPS-88501 Asset Publisher escapes Web Content articles' friendly URL

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
@@ -249,16 +249,6 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 							printAssetURL.setParameter("type", assetRendererFactory.getType());
 							printAssetURL.setParameter("languageId", LanguageUtil.getLanguageId(request));
 
-							String urlTitle = assetRenderer.getUrlTitle(locale);
-
-							if (Validator.isNotNull(urlTitle)) {
-								if (assetRenderer.getGroupId() != scopeGroupId) {
-									printAssetURL.setParameter("groupId", String.valueOf(assetRenderer.getGroupId()));
-								}
-
-								printAssetURL.setParameter("urlTitle", urlTitle);
-							}
-
 							printAssetURL.setWindowState(LiferayWindowState.POP_UP);
 
 							String id = assetEntry.getEntryId() + StringUtil.randomId();

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -326,16 +326,6 @@ String viewInContextURL = assetRenderer.getURLViewInContext(liferayPortletReques
 							printAssetURL.setParameter("type", assetRendererFactory.getType());
 							printAssetURL.setParameter("languageId", LanguageUtil.getLanguageId(request));
 
-							String urlTitle = assetRenderer.getUrlTitle(locale);
-
-							if (Validator.isNotNull(urlTitle)) {
-								if (assetRenderer.getGroupId() != scopeGroupId) {
-									printAssetURL.setParameter("groupId", String.valueOf(assetRenderer.getGroupId()));
-								}
-
-								printAssetURL.setParameter("urlTitle", urlTitle);
-							}
-
 							printAssetURL.setWindowState(LiferayWindowState.POP_UP);
 							%>
 


### PR DESCRIPTION
Hi @pavel-savinov ,

I created a solution, based on [this comment](https://issues.liferay.com/browse/LPS-88501?focusedCommentId=1742465&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1742465).

This solves the problem, however the rendered URL will contain the `assetEntryId` instead of the `urlTitle`. I think it is acceptable for the printing links.

I had another idea as well about adding % sign in front of every `urlTitle` variable in [routes.xml](https://github.com/liferay/liferay-portal/blob/master/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/friendly-url-routes/routes.xml). However, that would not always work: when the friendly URL contains a "/" sign, the regexp match for `(?!id$)[^/]+` will fail, and the URL will never be rendered correctly.

Please review my changes.

Thanks,
Vendel