### PR TITLE
LPS-97060 Avoid getDDMTemplates() executed for some cases. For example, after select one article to display and no use other templates to display, at this time, _ddmTemplateKey is blank; When journalContent configuration uses the selected article's template to display (_ddmTemplateKey==article.getDDMTemplateKey()) by setting "Use a specific template", we may directly return the article's templateKey;

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -402,6 +402,12 @@ public class JournalContentDisplayContext {
 			return _ddmTemplateKey;
 		}
 
+		if (Validator.isBlank(_ddmTemplateKey) ||
+			_ddmTemplateKey.equals(article.getDDMTemplateKey())) {
+
+			return article.getDDMTemplateKey();
+		}
+
 		List<DDMTemplate> ddmTemplates = getDDMTemplates();
 
 		Stream<DDMTemplate> stream = ddmTemplates.stream();


### PR DESCRIPTION
Hi @pavel-savinov, this is an attempt to reduce getDDMTemplates() invocations. With this we have a small performance gain. Could you, or the team, review this pull to make sure we don't break business logic? Thanks!  cc @yuhai @tinatian