### PR TITLE
LPS-96245 | Imported document within fragment cannot be seen

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/FragmentEntryLinkExportImportContentProcessor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/FragmentEntryLinkExportImportContentProcessor.java
@@ -72,6 +72,10 @@ public class FragmentEntryLinkExportImportContentProcessor
 			boolean escapeContent)
 		throws Exception {
 
+		content = _dlReferencesExportImportContentProcessor.
+			replaceExportContentReferences(
+				portletDataContext, stagedModel, content, true, false);
+
 		JSONObject editableValuesJSONObject = JSONFactoryUtil.createJSONObject(
 			content);
 
@@ -113,6 +117,10 @@ public class FragmentEntryLinkExportImportContentProcessor
 			PortletDataContext portletDataContext, StagedModel stagedModel,
 			String content)
 		throws Exception {
+
+		content = _dlReferencesExportImportContentProcessor.
+			replaceImportContentReferences(
+				portletDataContext, stagedModel, content);
 
 		JSONObject editableValuesJSONObject = JSONFactoryUtil.createJSONObject(
 			content);
@@ -400,6 +408,10 @@ public class FragmentEntryLinkExportImportContentProcessor
 
 	@Reference
 	private DDMTemplateLocalService _ddmTemplateLocalService;
+
+	@Reference(target = "(content.processor.type=DLReferences)")
+	private ExportImportContentProcessor<String>
+		_dlReferencesExportImportContentProcessor;
 
 	@Reference
 	private Portal _portal;


### PR DESCRIPTION
Hi @pavel-savinov, 

I'm using the existing methods in DLReferencesExportImportContentProcessor to process url references to documents. 

Please let me know if you have any questions. Thanks! 

cc @jkappler