### PR TITLE
[TECHNICAL-SUPPORT] LPS-103273 Use encoded name for embedded geolocation field

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/geolocation.ftl
+++ b/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/geolocation.ftl
@@ -1,5 +1,11 @@
 <#include "init.ftl">
 
+<#assign encodedName = name />
+
+<#if !repeatable>
+	<#assign encodedName = stringUtil.replace(name, ".", "_") />
+</#if>
+
 <#if stringUtil.equals(language, "ftl")>
 	${r"<#assign"} latitude = 0>
 	${r"<#assign"} longitude = 0>
@@ -14,7 +20,7 @@
 			geolocation=true
 			latitude=latitude
 			longitude=longitude
-			name="${name}${r"${randomizer.nextInt()}"}"
+			name="${encodedName}${r"${randomizer.nextInt()}"}"
 		/>
 	${r"</#if>"}
 <#else>


### PR DESCRIPTION
Hi @pavel-savinov ,

I'm resending this PR, based on comment: https://github.com/brianchandotcom/liferay-portal/pull/79741#issuecomment-544008364

Geolocation template only works when there's no "." character in its `name` attribute. When the field is repeatable, this replacement is already done in [init.ftl](https://github.com/liferay/liferay-portal/blob/c7745b914b12f66b20c6f76617288b0e4d3c7da3/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/init.ftl#L3-L5).
That's why only non-repeatable embedded geolocation fields should be handled here, to avoid replacing the string twice.

Please review my changes.

Thanks,
Vendel