### PR TITLE
[TS] LPS-110227

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
@@ -427,7 +427,7 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 
 		String instanceId = jsonObject.getString("instanceId");
 		Portlet portlet = _portletLocalService.getPortletById(
-			SegmentsExperiencePortletUtil.decodePortletName(portletId));
+			PortletIdCodec.decodePortletName(portletId));
 		PortletPreferences portletPreferences = null;
 
 		OptionalLong segmentsExperienceIdOptionalLong =

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetExperienceUsedPortletsMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetExperienceUsedPortletsMVCResourceCommand.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
@@ -76,7 +77,7 @@ public class GetExperienceUsedPortletsMVCResourceCommand
 
 				if (portletSegmentsExperienceId == segmentsExperienceId) {
 					jsonArray.put(
-						SegmentsExperiencePortletUtil.decodePortletName(
+						PortletIdCodec.decodePortletName(
 							portletPreferences.getPortletId()));
 				}
 			});

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/util/SegmentsExperiencePortletUtil.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/util/SegmentsExperiencePortletUtil.java
@@ -23,14 +23,13 @@ import com.liferay.segments.constants.SegmentsExperienceConstants;
  */
 public class SegmentsExperiencePortletUtil {
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 * 		PortletIdCodec#decodePortletName(String)}
+	 */
+	@Deprecated
 	public static String decodePortletName(String portletId) {
-		int index = portletId.indexOf(_SEGMENTS_EXPERIENCE_SEPARATOR);
-
-		if (index == -1) {
-			return PortletIdCodec.decodePortletName(portletId);
-		}
-
-		return PortletIdCodec.decodePortletName(portletId.substring(0, index));
+		return PortletIdCodec.decodePortletName(portletId);
 	}
 
 	public static long getSegmentsExperienceId(String portletId) {

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletIdCodec.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletIdCodec.java
@@ -41,7 +41,14 @@ public class PortletIdCodec {
 			return null;
 		}
 
-		return portletId.substring(index + _INSTANCE_SEPARATOR.length());
+		int index2 = portletId.indexOf(_SEGMENTS_EXPERIENCE_SEPARATOR);
+
+		if (index2 == -1) {
+			index2 = portletId.length();
+		}
+
+		return portletId.substring(
+			index + _INSTANCE_SEPARATOR.length(), index2);
 	}
 
 	public static String decodePortletName(String portletId) {
@@ -55,6 +62,12 @@ public class PortletIdCodec {
 
 		if (y != -1) {
 			return portletId.substring(0, y);
+		}
+
+		int z = portletId.indexOf(_SEGMENTS_EXPERIENCE_SEPARATOR);
+
+		if (z != -1) {
+			return portletId.substring(0, z);
 		}
 
 		return portletId;
@@ -196,6 +209,9 @@ public class PortletIdCodec {
 		if (portletName.contains(_INSTANCE_SEPARATOR)) {
 			keyword = _INSTANCE_SEPARATOR;
 		}
+		else if (portletName.contains(_SEGMENTS_EXPERIENCE_SEPARATOR)) {
+			keyword = _SEGMENTS_EXPERIENCE_SEPARATOR;
+		}
 		else if (portletName.contains(_USER_SEPARATOR)) {
 			keyword = _USER_SEPARATOR;
 		}
@@ -209,6 +225,9 @@ public class PortletIdCodec {
 	}
 
 	private static final String _INSTANCE_SEPARATOR = "_INSTANCE_";
+
+	private static final String _SEGMENTS_EXPERIENCE_SEPARATOR =
+		"_SEGMENTS_EXPERIENCE_";
 
 	private static final String _USER_SEPARATOR = "_USER_";
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/portlet/PortletIdCodecTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/portlet/PortletIdCodecTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.portlet;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.PortletConstants;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
 import com.liferay.portal.kernel.util.ObjectValuePair;
@@ -32,6 +33,64 @@ public class PortletIdCodecTest {
 	@ClassRule
 	public static final CodeCoverageAssertor codeCoverageAssertor =
 		CodeCoverageAssertor.INSTANCE;
+
+	@Test
+	public void testDecodeInstanceIdWithSegmentedPortletId() {
+		String portletId = _TEST_PORTLET_NAME + _SEGMENTS_EXPERIENCE_SEPARATOR;
+
+		Assert.assertEquals(null, PortletIdCodec.decodeInstanceId(portletId));
+
+		String testInstanceId = "1234";
+
+		portletId =
+			PortletIdCodec.encode(_TEST_PORTLET_NAME, testInstanceId) +
+				_SEGMENTS_EXPERIENCE_SEPARATOR;
+
+		Assert.assertEquals(
+			testInstanceId, PortletIdCodec.decodeInstanceId(portletId));
+
+		portletId =
+			PortletIdCodec.encode(_TEST_PORTLET_NAME, 1234) +
+				_SEGMENTS_EXPERIENCE_SEPARATOR;
+
+		Assert.assertEquals(null, PortletIdCodec.decodeInstanceId(portletId));
+
+		portletId =
+			PortletIdCodec.encode(_TEST_PORTLET_NAME, 1234, testInstanceId) +
+				_SEGMENTS_EXPERIENCE_SEPARATOR;
+
+		Assert.assertEquals(
+			testInstanceId, PortletIdCodec.decodeInstanceId(portletId));
+	}
+
+	@Test
+	public void testDecodePortletNameWithSegmentedPortletId() {
+		String portletId = _TEST_PORTLET_NAME + _SEGMENTS_EXPERIENCE_SEPARATOR;
+
+		Assert.assertEquals(
+			_TEST_PORTLET_NAME, PortletIdCodec.decodePortletName(portletId));
+
+		portletId =
+			PortletIdCodec.encode(_TEST_PORTLET_NAME, "1234") +
+				_SEGMENTS_EXPERIENCE_SEPARATOR;
+
+		Assert.assertEquals(
+			_TEST_PORTLET_NAME, PortletIdCodec.decodePortletName(portletId));
+
+		portletId =
+			PortletIdCodec.encode(_TEST_PORTLET_NAME, 1234) +
+				_SEGMENTS_EXPERIENCE_SEPARATOR;
+
+		Assert.assertEquals(
+			_TEST_PORTLET_NAME, PortletIdCodec.decodePortletName(portletId));
+
+		portletId =
+			PortletIdCodec.encode(_TEST_PORTLET_NAME, 1234, "1234") +
+				_SEGMENTS_EXPERIENCE_SEPARATOR;
+
+		Assert.assertEquals(
+			_TEST_PORTLET_NAME, PortletIdCodec.decodePortletName(portletId));
+	}
 
 	@Test
 	public void testEncodeDecode() {
@@ -374,7 +433,32 @@ public class PortletIdCodecTest {
 					"\" must not contain the keyword _INSTANCE_",
 				invalidParameterException.getMessage());
 		}
+
+		// Test 6
+
+		String segmentedPortletName =
+			portletName + _SEGMENTS_EXPERIENCE_SEPARATOR;
+
+		try {
+			PortletIdCodec.validatePortletName(segmentedPortletName);
+
+			Assert.fail();
+		}
+		catch (InvalidParameterException invalidParameterException) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append("The portlet name \"");
+			sb.append(segmentedPortletName);
+			sb.append("\" must not contain the keyword ");
+			sb.append(_SEGMENTS_EXPERIENCE_SEPARATOR);
+
+			Assert.assertEquals(
+				sb.toString(), invalidParameterException.getMessage());
+		}
 	}
+
+	private static final String _SEGMENTS_EXPERIENCE_SEPARATOR =
+		"_SEGMENTS_EXPERIENCE_";
 
 	private static final String _TEST_PORTLET_NAME =
 		"com_liferay_test_portlet_TestPortlet";


### PR DESCRIPTION
Hi @pavel-savinov ,


The root cause of the issue is here: [github](https://github.com/liferay/liferay-portal/blob/7b978c659cc2ebcd5e8594c247d39893f10bd4d0/portal-impl/src/com/liferay/portlet/internal/PortletContainerImpl.java#L809)

```
if ((portlet != null) && portlet.isInstanceable() &&
    !portlet.isAddDefaultResource() &&
    !Validator.isPassword(portlet.getInstanceId())) {    

    if (_log.isDebugEnabled()) {
        _log.debug(
            StringBundler.concat(
                "Portlet ", portlet.getPortletId(),
                " is instanceable but does not have a valid instance ",
                "id"));
    }

    portlet = null;
}
```
In segmented portlet's case getInstanceId() would return something similar to this:  
'Q9XSq7SMTwld_SEGMENTS_EXPERIENCE_38457'
which won't validate as a password due to the underscores.

I think we have to make a small coupling between portal-kernel and the segmentation modules. Making kernel loosely aware of the _SEGMENTS_EXPERIENCE_SEPARATOR looks the safest for me.
I'm not sure if the rest of SegmentsExperiencePortletUtil.java should be moved to PortletIdCodec.java as well.

Can you please review?
https://issues.liferay.com/browse/LPS-110227

Thanks,
Balázs