### PR TITLE
LPS-86235 Preference can not be unique per layout - DummyFolder

### DIFF
--- a/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/internal/portlet/DummyFolderPortlet.java
+++ b/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/internal/portlet/DummyFolderPortlet.java
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	immediate = true,
 	property = {
+		"com.liferay.portlet.preferences-unique-per-layout=false",
 		"javax.portlet.name=" + DummyFolderPortletKeys.DUMMY_FOLDER,
 		"javax.portlet.resource-bundle=content.Language"
 	},


### PR DESCRIPTION
Hi @pavel-savinov  ,
I am fixing an issue where several site level portlets have preference of unique per layout and several instance portlets have data level at SITE. (Some example of site level portlets are those *AdminPortlet, and what I meant for instance portlets are those portlets that can be deployed)
I am not sure if this DummyFolderPortlet is a site level or instance level portlet, as it's in test-util and has no indication. I assume it's a site level portlet, and made it unique-per-layout = false.
See LPS-86235 and its parrent ticket for detailed background.