### PR TITLE
LPS-124706 Preserve existing fragment configurations

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/EditableValuesTransformerUtil.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/EditableValuesTransformerUtil.java
@@ -166,7 +166,7 @@ public class EditableValuesTransformerUtil {
 		JSONObject jsonObject, long segmentsExperienceId) {
 
 		if (!jsonObject.has(_ID_PREFIX + segmentsExperienceId)) {
-			return JSONFactoryUtil.createJSONObject();
+			return jsonObject;
 		}
 
 		return jsonObject.getJSONObject(_ID_PREFIX + segmentsExperienceId);


### PR DESCRIPTION
Hi @pavel-savinov  

We've been seeing a number of fragment styling configs getting lost after upgrading to 7.3, for example cases like the following: 

```
  {
    "com.liferay.fragment.entry.processor.background.image.BackgroundImageFragmentEntryProcessor": {},
    "com.liferay.fragment.entry.processor.editable.EditableFragmentEntryProcessor": {
      "link": { "defaultValue": "Go Somewhere", "config": {} }
    },
    "com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor": {
      "buttonType": "secondary"
    }
  }
```

will get changed to 

```
 {
    "com.liferay.fragment.entry.processor.background.image.BackgroundImageFragmentEntryProcessor": {},
    "com.liferay.fragment.entry.processor.editable.EditableFragmentEntryProcessor": {
      "link": { "defaultValue": "Go Somewhere", "config": {} }
    },
    "com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor": {}
  }
```
This is because the upgrade step only includes settings from `com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor` that have an experience. But there are cases (e.g. display page templates) where we have configurations without experiences and the upgrade step is just removing these. 

I made this fix which solves a lot of styling issues for us. Can you please take a look? 
