### PR TITLE
LPS-125409 Only set languageId when portal locale and FriendlyURL locale match

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/DefaultAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/DefaultAssetDisplayPageFriendlyURLResolver.java
@@ -68,6 +68,7 @@ import com.liferay.portal.kernel.workflow.permission.WorkflowPermissionUtil;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.portlet.WindowState;
@@ -300,9 +301,13 @@ public class DefaultAssetDisplayPageFriendlyURLResolver
 			locale = LocaleUtil.fromLanguageId(
 				friendlyURLEntryLocalization.getLanguageId());
 
-			actualParams.put(
-				namespace + "languageId",
-				new String[] {friendlyURLEntryLocalization.getLanguageId()});
+			if (Objects.equals(_portal.getLocale(httpServletRequest), locale)) {
+				actualParams.put(
+					namespace + "languageId",
+					new String[] {
+						friendlyURLEntryLocalization.getLanguageId()
+					});
+			}
 		}
 
 		String queryString = _http.parameterMapToString(actualParams, false);


### PR DESCRIPTION
Hi @pavel-savinov,

In order to avoid LPS-108651, I propose to only set languageId if portal Locale and friendlyURLEntryLocalization's locale match.

Could you please review it and forward it if you do not see any objection?

Thanks in advance